### PR TITLE
 chore: Merge branch dev to main

### DIFF
--- a/patches/build.gradle.kts
+++ b/patches/build.gradle.kts
@@ -1,14 +1,13 @@
-group = "app.template"
+group = "app.mvaishak"
 
 patches {
-    // TODO: Update this section with your project details.
     about {
-        name = "UserXYZ Patches"
-        description = "Patches for apps I like"
-        source = "git@github.com:UserXYZ/morphe-patches.git"
-        author = "Awesome dev"
+        name = "mvaishak Letterboxd Patches"
+        description = "Personal patches for the Letterboxd Android app"
+        source = "git@github.com:mvaishak/letterboxd-morphe-patches.git"
+        author = "mvaishak"
         contact = "na"
-        website = "na"
+        website = "https://github.com/mvaishak/letterboxd-morphe-patches"
         license = "GPLv3"
     }
 }

--- a/patches/src/main/kotlin/app/template/patches/letterboxd/BottomNavColorPatch.kt
+++ b/patches/src/main/kotlin/app/template/patches/letterboxd/BottomNavColorPatch.kt
@@ -1,0 +1,42 @@
+package app.template.patches.letterboxd
+
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.resourcePatch
+import app.template.patches.shared.Constants.COMPATIBILITY_LETTERBOXD
+import org.w3c.dom.Element
+
+private const val BOTTOM_NAV_STYLE = "Widget.Letterboxd.BottomNavigationView"
+
+// Letterboxd's top app bar (Widget.Letterboxd.AppBarLayout) uses this color as its background.
+private const val TOP_BAR_COLOR = "@color/black100"
+
+@Suppress("unused")
+val bottomNavColorPatch = resourcePatch(
+    name = "Match bottom nav to top bar color",
+    description = "Sets Letterboxd's bottom navigation bar background to the same color as the top bar " +
+        "($TOP_BAR_COLOR), so it blends into the app's dark chrome instead of showing the default slate bar.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LETTERBOXD)
+
+    execute {
+        document("res/values/styles.xml").use { document ->
+            val styles = document.getElementsByTagName("style")
+
+            val bottomNavStyle = (0 until styles.length)
+                .map { styles.item(it) as Element }
+                .firstOrNull { it.getAttribute("name") == BOTTOM_NAV_STYLE }
+                ?: throw PatchException("Could not find <style name=\"$BOTTOM_NAV_STYLE\"> in res/values/styles.xml")
+
+            val items = bottomNavStyle.getElementsByTagName("item")
+            val background = (0 until items.length)
+                .map { items.item(it) as Element }
+                .firstOrNull { it.getAttribute("name") == "android:background" }
+                ?: throw PatchException("Style \"$BOTTOM_NAV_STYLE\" has no <item name=\"android:background\"> to patch")
+
+            // Was @color/gray445566 (#445566), which is also colorPrimary and therefore
+            // cannot be swapped safely in colors.xml.
+            background.textContent = TOP_BAR_COLOR
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -74,4 +74,17 @@ object Constants {
             )
         )
     )
+
+    val COMPATIBILITY_LETTERBOXD = Compatibility(
+        name = "Letterboxd", // App name as it appears in the Android launcher.
+        packageName = "com.letterboxd.letterboxd",
+        apkFileType = ApkFileType.APK, // Change to APKM if you patch a split bundle from ApkMirror.
+        appIconColor = 0xFF8000, // Letterboxd brand orange.
+        targets = listOf(
+            // Last version confirmed 100% working with these patches.
+            AppTarget(
+                version = "3.5.4"
+            )
+        )
+    )
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "morphe-patches-template"
+rootProject.name = "letterboxd-dark-theme"
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
Promotes the current dev pre-release to a stable release.

What's included

New patch — "Match bottom nav to top bar color" (com.letterboxd.letterboxd, target 3.5.4)

A resourcePatch that rewrites the android:background item of the Widget.Letterboxd.BottomNavigationView style in res/values/styles.xml from @color/gray445566 (#445566) to @color/black100 — the color Letterboxd uses for the top app bar (Widget.Letterboxd.AppBarLayout). The bottom navigation bar then blends into the app's dark chrome instead of showing the default slate bar.

@color/gray445566 is also colorPrimary, so it can't be swapped in colors.xml without affecting the whole app — the patch targets the style item directly and throws a PatchException if the style or item is missing (e.g. on a future app version).

- default = true — selected automatically when a Letterboxd APK is loaded
- Added COMPATIBILITY_LETTERBOXD to Constants.kt